### PR TITLE
chore(1.18): update to minecraft 1.18

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,5 @@ buildNumber.properties
 .settings/org.eclipse.m2e.core.prefs
 
 *.iml
+/spigotServer/*
+/libs/item-nbt-api-plugin-2.9.0-SNAPSHOT.jar

--- a/pom.xml
+++ b/pom.xml
@@ -4,8 +4,8 @@
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
 
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xmlns="http://maven.apache.org/POM/4.0.0"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <artifactId>Craftory</artifactId>
   <url>brettsaunders.tech</url>
   <version>0.6.0</version>
@@ -32,7 +32,7 @@
             </relocation>
             <relocation>
               <pattern>de.tr7zw.changeme.nbtapi</pattern>
-              <shadedPattern>tech.brettsaunders.craftory.external</shadedPattern>
+              <shadedPattern>tech.brettsaunders.craftory.nbtapi</shadedPattern>
             </relocation>
             <relocation>
               <pattern>io.github.bakedlibs.dough</pattern>
@@ -100,7 +100,7 @@
     <dependency>
       <groupId>de.tr7zw</groupId>
       <artifactId>item-nbt-api</artifactId>
-      <version>2.8.0</version>
+      <version>2.9.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>io.sentry</groupId>
@@ -155,7 +155,7 @@
   <packaging>jar</packaging>
   <properties>
     <author>BrettSaunders</author>
-    <java.version>1.8</java.version>
+    <java.version>1.17</java.version>
     <mainClass>tech.brettsaunders.craftory.Craftory</mainClass>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <sonar.projectKey>CraftoryStudios_Craftory-Tech</sonar.projectKey>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
             </relocation>
             <relocation>
               <pattern>de.tr7zw.changeme.nbtapi</pattern>
-              <shadedPattern>tech.brettsaunders.craftory.nbtapi</shadedPattern>
+              <shadedPattern>tech.brettsaunders.craftory.external</shadedPattern>
             </relocation>
             <relocation>
               <pattern>io.github.bakedlibs.dough</pattern>

--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
       <artifactId>spigot-api</artifactId>
       <groupId>org.spigotmc</groupId>
       <scope>provided</scope>
-      <version>1.17-R0.1-SNAPSHOT</version>
+      <version>1.18-R0.1-SNAPSHOT</version>
     </dependency>
     <dependency>
       <artifactId>bstats-bukkit</artifactId>

--- a/src/main/java/tech/brettsaunders/craftory/Craftory.java
+++ b/src/main/java/tech/brettsaunders/craftory/Craftory.java
@@ -75,7 +75,7 @@ public final class Craftory extends JavaPlugin implements Listener {
   private SentryClient sentryClient;
   private static HashSet<String> loadedPlugins = new HashSet<>();
 
-  public static final Version MAX_SUPPORTED_MC = new Version("1.17.1");
+  public static final Version MAX_SUPPORTED_MC = new Version("1.18");
   public static final Version MIN_SUPPORTED_MC = new Version("1.15.1");
   public static boolean isCaveAndCliffsUpdate;
   public static Version mcVersion;


### PR DESCRIPTION

NBT api is currently on snapshot version for 1.18 but it is working fine. Tested it in spigot and everything seems ok.