### PR TITLE
fix(blocks): change order of block placement actions to fix protection

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,13 +130,13 @@
     <dependency>
       <groupId>io.github.baked-libs</groupId>
       <artifactId>dough-protection</artifactId>
-      <version>1.0.3</version>
+      <version>1.1.1</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.github.baked-libs</groupId>
       <artifactId>dough-common</artifactId>
-      <version>1.0.3</version>
+      <version>1.1.1</version>
     </dependency>
     <dependency>
       <groupId>de.robotricker</groupId>


### PR DESCRIPTION
Currently protection plugin checks are called on block place before we check if a custom block is being placed. We should only cancel the block place event if we are sure the block belongs to our plugin.

This also removes the check for if cancelled and instead passes it to the event handler.